### PR TITLE
increase horizon nginx proxy worker connections from 10k to 50k

### DIFF
--- a/deploy/ansible/playbooks/roles/horizon-nginx-proxy/templates/docker-compose.yml.j2
+++ b/deploy/ansible/playbooks/roles/horizon-nginx-proxy/templates/docker-compose.yml.j2
@@ -3,7 +3,7 @@ version: "3"
 
 services:
   horizon-nginx-proxy:
-    image: kinecosystem/horizon-nginx-proxy:885282e
+    image: kinecosystem/horizon-nginx-proxy:85c6b72
     container_name: horizon-nginx-proxy
 
     network_mode: host

--- a/images/docker-compose.yml
+++ b/images/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       POSTGRES_DB: horizon
 
   horizon-nginx-proxy:
-    image: kinecosystem/horizon-nginx-proxy:885282e
+    image: kinecosystem/horizon-nginx-proxy:latest
     ports:
       - 8008:80
     links:

--- a/images/dockerfiles/horizon-nginx-proxy/nginx.conf.tmpl
+++ b/images/dockerfiles/horizon-nginx-proxy/nginx.conf.tmpl
@@ -2,7 +2,7 @@ daemon off;  # run in foreground because docker
 pid /run/nginx.pid;
 worker_processes auto;
 events {
-  worker_connections 10000;
+  worker_connections 50000;
 }
 
 http {


### PR DESCRIPTION
this appears to be the cause for nginx to send TCP RST messages back to ELB - its worker connection pool was exhausted