### PR TITLE
add missing providers in terraform scripts

### DIFF
--- a/deploy/terraform/modules/horizon/ec2.tf
+++ b/deploy/terraform/modules/horizon/ec2.tf
@@ -113,16 +113,19 @@ output "ec2_security_group_id" {
 # data sources to get vpc, subnet, ami, route53 details
 
 data "aws_vpc" "default" {
+  provider = "aws.us-east-1"
   default = true
 }
 
 data "aws_subnet" "default" {
+  provider = "aws.us-east-1"
   vpc_id            = "${data.aws_vpc.default.id}"
   availability_zone = "${var.zone}"
   default_for_az    = true
 }
 
 data "aws_ami" "ubuntu" {
+  provider = "aws.us-east-1"
   most_recent = true
 
   owners = ["099720109477"] # canonical/ubuntu

--- a/deploy/terraform/modules/horizon/elb.tf
+++ b/deploy/terraform/modules/horizon/elb.tf
@@ -104,10 +104,12 @@ output "alb_zone_id" {
 }
 
 data "aws_acm_certificate" "kin" {
+  provider = "aws.us-east-1"
   domain   = "${var.certificate_domain_name}"
   statuses = ["ISSUED"]
 }
 
 data "aws_subnet_ids" "default" {
+  provider = "aws.us-east-1"
   vpc_id = "${data.aws_vpc.default.id}"
 }

--- a/deploy/terraform/modules/stellar-core/ec2.tf
+++ b/deploy/terraform/modules/stellar-core/ec2.tf
@@ -185,16 +185,19 @@ resource "aws_security_group_rule" "egress_apt_key_server" {
 # data sources to get vpc, subnet, ami, route53 details
 
 data "aws_vpc" "default" {
+  provider = "aws.us-east-1"
   default = true
 }
 
 data "aws_subnet" "default" {
+  provider = "aws.us-east-1"
   vpc_id            = "${data.aws_vpc.default.id}"
   availability_zone = "${var.zone}"
   default_for_az    = true
 }
 
 data "aws_ami" "ubuntu" {
+  provider = "aws.us-east-1"
   most_recent = true
 
   owners = ["099720109477"] # canonical/ubuntu
@@ -210,5 +213,6 @@ data "aws_ami" "ubuntu" {
 }
 
 data "aws_route53_zone" "kin" {
+  provider = "aws.us-east-1"
   name = "${format("%s.", var.tld)}"
 }


### PR DESCRIPTION
@avi-kik please approve these: explicitly stating the default (us-east-1) for terraform configuration files. these do not change the behaviour. however they are required so we know what needs to be modified when NOT installing to us-east-1. thx!