### PR TITLE
add network spam test and update helpers.py with related functions

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -260,6 +260,12 @@ def protocol_version_9():
     upgrade('protocolversion', 'protocol_version', 9)
 
 
+def tx_set_size_500():
+    """Set transactino set size to 500."""
+    print('Setting transaction set size to 500')
+    upgrade('maxtxsize', 'max_tx_set_size', 500)
+
+
 def derive_root_account_seed(passphrase):
     """Return the root account seed based on the given network passphrase."""
     network_hash = sha256(passphrase.encode()).digest()
@@ -339,6 +345,7 @@ def network(_):
     """Initialize a new local test network with single core and horizon instances."""
     base_reserve_0()
     protocol_version_9()
+    tx_set_size_500()
     create_whitelist_account()
 
     print('Root account seed: {}'.format(derive_root_account_seed('private testnet')))

--- a/tests/go/src/github.com/kinecosystem/core/.gitignore
+++ b/tests/go/src/github.com/kinecosystem/core/.gitignore
@@ -1,3 +1,2 @@
 /vendor
-/images/volumes
 /glide

--- a/tests/python/Pipfile
+++ b/tests/python/Pipfile
@@ -10,6 +10,9 @@ pylint = "*"
 
 [packages]
 kin-sdk = "==2.1.3"
+aiohttp = "*"
+cchardet = "*"
+aiodns = "*"
 
 [requires]
 python_version = "3.7"

--- a/tests/python/Pipfile.lock
+++ b/tests/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "35e3bd41adfd23828a209035bf1470cd3e37780b2913976e5a9064f5f0c6638b"
+            "sha256": "d648ba82c9b63989ec3df291fa97681f8d5d335a8707dc4bfdef928f589eb848"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,85 @@
         ]
     },
     "default": {
+        "aiodns": {
+            "hashes": [
+                "sha256:99d0652f2c02f73bfa646bf44af82705260a523014576647d7959e664830b26b",
+                "sha256:d8677adc679ce8d0ef706c14d9c3d2f27a0e0cc11d59730cdbaf218ad52dd9ea"
+            ],
+            "index": "pypi",
+            "version": "==1.1.1"
+        },
+        "aiohttp": {
+            "hashes": [
+                "sha256:0419705a36b43c0ac6f15469f9c2a08cad5c939d78bd12a5c23ea167c8253b2b",
+                "sha256:1812fc4bc6ac1bde007daa05d2d0f61199324e0cc893b11523e646595047ca08",
+                "sha256:2214b5c0153f45256d5d52d1e0cafe53f9905ed035a142191727a5fb620c03dd",
+                "sha256:275909137f0c92c61ba6bb1af856a522d5546f1de8ea01e4e726321c697754ac",
+                "sha256:3983611922b561868428ea1e7269e757803713f55b53502423decc509fef1650",
+                "sha256:51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db3475fa",
+                "sha256:589f2ec8a101a0f340453ee6945bdfea8e1cd84c8d88e5be08716c34c0799d95",
+                "sha256:789820ddc65e1f5e71516adaca2e9022498fa5a837c79ba9c692a9f8f916c330",
+                "sha256:7a968a0bdaaf9abacc260911775611c9a602214a23aeb846f2eb2eeaa350c4dc",
+                "sha256:7aeefbed253f59ea39e70c5848de42ed85cb941165357fc7e87ab5d8f1f9592b",
+                "sha256:7b2eb55c66512405103485bd7d285a839d53e7fdc261ab20e5bcc51d7aaff5de",
+                "sha256:87bc95d3d333bb689c8d755b4a9d7095a2356108002149523dfc8e607d5d32a4",
+                "sha256:9d80e40db208e29168d3723d1440ecbb06054d349c5ece6a2c5a611490830dd7",
+                "sha256:a1b442195c2a77d33e4dbee67c9877ccbdd3a1f686f91eb479a9577ed8cc326b",
+                "sha256:ab3d769413b322d6092f169f316f7b21cd261a7589f7e31db779d5731b0480d8",
+                "sha256:b066d3dec5d0f5aee6e34e5765095dc3d6d78ef9839640141a2b20816a0642bd",
+                "sha256:b24e7845ae8de3e388ef4bcfcf7f96b05f52c8e633b33cf8003a6b1d726fc7c2",
+                "sha256:c59a953c3f8524a7c86eaeaef5bf702555be12f5668f6384149fe4bb75c52698",
+                "sha256:cf2cc6c2c10d242790412bea7ccf73726a9a44b4c4b073d2699ef3b48971fd95",
+                "sha256:e0c9c8d4150ae904f308ff27b35446990d2b1dfc944702a21925937e937394c6",
+                "sha256:f1839db4c2b08a9c8f9788112644f8a8557e8e0ecc77b07091afabb941dc55d0",
+                "sha256:f3df52362be39908f9c028a65490fae0475e4898b43a03d8aa29d1e765b45e07"
+            ],
+            "index": "pypi",
+            "version": "==3.4.4"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
+                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
+            ],
+            "version": "==3.0.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
+        "cchardet": {
+            "hashes": [
+                "sha256:079aa02a14072874d943a671ba778a9def5b0e3cedc2ac9f59308526cfb31472",
+                "sha256:3e048a21688dcb4c797f40c8deb3600887bcaf435620256fd8becd4252012750",
+                "sha256:41fced7a6f05ef859fe3eac89fc2120aca3cbbfd2b6c803bed3ee4bf02956903",
+                "sha256:440903d5dca3d326f4b841e7fa760b6af1be4f950ead1a6ff77b76eaa46f0cd3",
+                "sha256:50170f346527c5df4d3cb94648ca187c666e61c0db6e510b984e867c44709d8b",
+                "sha256:6c55a6e7bc7337671c9f1ad90746c0efb2b2979ff4305c7ca1d7d381f05174c1",
+                "sha256:7f581ea172b252034f745dfd49733966b73b73907bdef0b47ad5f2008b797d54",
+                "sha256:80f7b087198827e60c81574c321b12f89188eae626ae1567d66808928be42f88",
+                "sha256:8ba753ff73ca2f3554999a0e027eab9450f6ffdb7e92e1b4e13b52be89995349",
+                "sha256:9ad8f61d6d1ca37bd4b954ad92d461ea4f58d0dc413b0790a5abed7c09e54996",
+                "sha256:a35bd23cedbaa87cc9300af1dd10bb03fda41894045fbca7bfdf1d350b813f25",
+                "sha256:a8feb9a7def2310e18c27e485a21a38669abe8c2e36b93c6ce1a1363495d4cdf",
+                "sha256:aa9dd4cee8a5210a6d0a7b263b98dc50637e00401fc4a5ad3ce2dbef54fdfa02",
+                "sha256:ab9858a0673262e467619df91f425cfef0590dcf5deef5c0c7945e9dc4dbd7d8",
+                "sha256:b09a488bbb35be95f82845e3c4312be9025e8377975b027eee67e0b39445e070",
+                "sha256:b2893d558761b3534cddf5a49ba8d77df3d8f964d7b14680b925f4a85fc13476",
+                "sha256:b5a8f9b229a30cd2432572d15e169483bc47c24418772ff58d0585050631c2fd",
+                "sha256:bded54eeccd5f810bc69e076b3d9a35819a92e5e0559ad274b9ae9061b1b881d",
+                "sha256:cbc206061e69561af6e4cba11f99abd928346c6b5bcdc83eb32ae40e9fc23a5f",
+                "sha256:cc9745e0400da4cfb49f075e7819f22473b66443f953427058fee2c7b9547cc0",
+                "sha256:db30bf3825702c07fc55a290d41663fd8151f870642a15667bbabf81fff21e0b",
+                "sha256:eeeb1b95bb5851dda93ee522860a0e6066d47921cb1d540cb778346e37e5a524",
+                "sha256:f1c3919fb71ac5da3aeee42c5b731c99dcd2beed71db7fdc28ca993c173f0402"
+            ],
+            "index": "pypi",
+            "version": "==2.1.4"
+        },
         "certifi": {
             "hashes": [
                 "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
@@ -80,6 +159,40 @@
             ],
             "version": "==0.18"
         },
+        "multidict": {
+            "hashes": [
+                "sha256:024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f",
+                "sha256:041e9442b11409be5e4fc8b6a97e4bcead758ab1e11768d1e69160bdde18acc3",
+                "sha256:045b4dd0e5f6121e6f314d81759abd2c257db4634260abcfe0d3f7083c4908ef",
+                "sha256:047c0a04e382ef8bd74b0de01407e8d8632d7d1b4db6f2561106af812a68741b",
+                "sha256:068167c2d7bbeebd359665ac4fff756be5ffac9cda02375b5c5a7c4777038e73",
+                "sha256:148ff60e0fffa2f5fad2eb25aae7bef23d8f3b8bdaf947a65cdbe84a978092bc",
+                "sha256:1d1c77013a259971a72ddaa83b9f42c80a93ff12df6a4723be99d858fa30bee3",
+                "sha256:1d48bc124a6b7a55006d97917f695effa9725d05abe8ee78fd60d6588b8344cd",
+                "sha256:31dfa2fc323097f8ad7acd41aa38d7c614dd1960ac6681745b6da124093dc351",
+                "sha256:34f82db7f80c49f38b032c5abb605c458bac997a6c3142e0d6c130be6fb2b941",
+                "sha256:3d5dd8e5998fb4ace04789d1d008e2bb532de501218519d70bb672c4c5a2fc5d",
+                "sha256:4a6ae52bd3ee41ee0f3acf4c60ceb3f44e0e3bc52ab7da1c2b2aa6703363a3d1",
+                "sha256:4b02a3b2a2f01d0490dd39321c74273fed0568568ea0e7ea23e02bd1fb10a10b",
+                "sha256:4b843f8e1dd6a3195679d9838eb4670222e8b8d01bc36c9894d6c3538316fa0a",
+                "sha256:5de53a28f40ef3c4fd57aeab6b590c2c663de87a5af76136ced519923d3efbb3",
+                "sha256:61b2b33ede821b94fa99ce0b09c9ece049c7067a33b279f343adfe35108a4ea7",
+                "sha256:6a3a9b0f45fd75dc05d8e93dc21b18fc1670135ec9544d1ad4acbcf6b86781d0",
+                "sha256:76ad8e4c69dadbb31bad17c16baee61c0d1a4a73bed2590b741b2e1a46d3edd0",
+                "sha256:7ba19b777dc00194d1b473180d4ca89a054dd18de27d0ee2e42a103ec9b7d014",
+                "sha256:7c1b7eab7a49aa96f3db1f716f0113a8a2e93c7375dd3d5d21c4941f1405c9c5",
+                "sha256:7fc0eee3046041387cbace9314926aa48b681202f8897f8bff3809967a049036",
+                "sha256:8ccd1c5fff1aa1427100ce188557fc31f1e0a383ad8ec42c559aabd4ff08802d",
+                "sha256:8e08dd76de80539d613654915a2f5196dbccc67448df291e69a88712ea21e24a",
+                "sha256:c18498c50c59263841862ea0501da9f2b3659c00db54abfbf823a80787fde8ce",
+                "sha256:c49db89d602c24928e68c0d510f4fcf8989d77defd01c973d6cbe27e684833b1",
+                "sha256:ce20044d0317649ddbb4e54dab3c1bcc7483c78c27d3f58ab3d0c7e6bc60d26a",
+                "sha256:d1071414dd06ca2eafa90c85a079169bfeb0e5f57fd0b45d44c092546fcd6fd9",
+                "sha256:d3be11ac43ab1a3e979dac80843b42226d5d3cccd3986f2e03152720a4297cd7",
+                "sha256:db603a1c235d110c860d5f39988ebc8218ee028f07a7cbc056ba6424372ca31b"
+            ],
+            "version": "==4.5.2"
+        },
         "numpy": {
             "hashes": [
                 "sha256:0df89ca13c25eaa1621a3f09af4c8ba20da849692dcae184cb55e80952c453fb",
@@ -118,6 +231,32 @@
                 "sha256:ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"
             ],
             "version": "==1.3"
+        },
+        "pycares": {
+            "hashes": [
+                "sha256:0e81c971236bb0767354f1456e67ab6ae305f248565ce77cd413a311f9572bf5",
+                "sha256:11c0ff3ccdb5a838cbd59a4e59df35d31355a80a61393bca786ca3b44569ba10",
+                "sha256:170d62bd300999227e64da4fa85459728cc96e62e44780bbc86a915fdae01f78",
+                "sha256:36f4c03df57c41a87eb3d642201684eb5a8bc194f4bafaa9f60ee6dc0aef8e40",
+                "sha256:371ce688776da984c4105c8ca760cc60944b9b49ccf8335c71dc7669335e6173",
+                "sha256:3a2234516f7db495083d8bba0ccdaabae587e62cfcd1b8154d5d0b09d3a48dfc",
+                "sha256:3f288586592c697109b2b06e3988b7e17d9765887b5fc367010ee8500cbddc86",
+                "sha256:40134cee03c8bbfbc644d4c0bc81796e12dd012a5257fb146c5a5417812ee5f7",
+                "sha256:722f5d2c5f78d47b13b0112f6daff43ce4e08e8152319524d14f1f917cc5125e",
+                "sha256:7b18fab0ed534a898552df91bc804bd62bb3a2646c11e054baca14d23663e1d6",
+                "sha256:8a39d03bd99ea191f86b990ef67ecce878d6bf6518c5cde9173fb34fb36beb5e",
+                "sha256:8ea263de8bf1a30b0d87150b4aa0e3203cf93bc1723ea3e7408a7d25e1299217",
+                "sha256:943e2dc67ff45ab4c81d628c959837d01561d7e185080ab7a276b8ca67573fb5",
+                "sha256:9d56a54c93e64b30c0d31f394d9890f175edec029cd846221728f99263cdee82",
+                "sha256:b95b339c11d824f0bb789d31b91c8534916fcbdce248cccce216fa2630bb8a90",
+                "sha256:bbfd9aba1e172cd2ab7b7142d49b28cf44d6451c4a66a870aff1dc3cb84849c7",
+                "sha256:d8637bcc2f901aa61ec1d754abc862f9f145cb0346a0249360df4c159377018e",
+                "sha256:e2446577eeea79d2179c9469d9d4ce3ab8a07d7985465c3cb91e7d74abc329b6",
+                "sha256:e72fa163f37ae3b09f143cc6690a36f012d13e905d142e1beed4ec0e593ff657",
+                "sha256:f32b7c63094749fbc0c1106c9a785666ec8afd49ecfe7002a30bb7c42e62b47c",
+                "sha256:f50be4dd53f009cfb4b98c3c6b240e18ff9b17e3f1c320bd594bb83eddabfcb2"
+            ],
+            "version": "==2.3.0"
         },
         "requests": {
             "hashes": [
@@ -159,6 +298,20 @@
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
             "version": "==1.24.1"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
+                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
+                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
+                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
+                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
+                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8",
+                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
+                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
+                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
+            ],
+            "version": "==1.2.6"
         }
     },
     "develop": {

--- a/tests/python/create.py
+++ b/tests/python/create.py
@@ -1,0 +1,43 @@
+"""Create accounts."""
+import asyncio
+import argparse
+import logging
+
+from kin import KinClient, Environment
+from kin.blockchain.builder import Builder
+
+from helpers import (NETWORK_NAME, MIN_FEE,
+                     root_account_seed, create_accounts)
+
+
+STARTING_BALANCE = 1e5
+
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+
+
+def parse_args():
+    """Generate and parse CLI arguments."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--accounts', required=True, type=int, help='Amount of accounts to create')
+    parser.add_argument('--passphrase', required=True, type=str, help='Network passphrase')
+    parser.add_argument('--horizon', required=True, type=str, help='Horizon endpoint URL')
+
+    return parser.parse_args()
+
+
+async def main():
+    """Create accounts and print their seeds to stdout."""
+    args = parse_args()
+    env = Environment(NETWORK_NAME, args.horizon, args.passphrase)
+    builder = Builder(NETWORK_NAME, KinClient(env).horizon, MIN_FEE, root_account_seed(args.passphrase))
+    builder.sequence = builder.get_sequence()
+    kps = await create_accounts(builder, args.accounts, STARTING_BALANCE)
+
+    for kp in kps:
+        print(kp.secret_seed)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/python/create.py
+++ b/tests/python/create.py
@@ -22,7 +22,8 @@ def parse_args():
 
     parser.add_argument('--accounts', required=True, type=int, help='Amount of accounts to create')
     parser.add_argument('--passphrase', required=True, type=str, help='Network passphrase')
-    parser.add_argument('--horizon', required=True, type=str, help='Horizon endpoint URL')
+    parser.add_argument('--horizon', action='append',
+                        help='Horizon endpoint URL (use multiple --horizon flags for multiple addresses)')
 
     return parser.parse_args()
 
@@ -30,10 +31,10 @@ def parse_args():
 async def main():
     """Create accounts and print their seeds to stdout."""
     args = parse_args()
-    env = Environment(NETWORK_NAME, args.horizon, args.passphrase)
+    env = Environment(NETWORK_NAME, (args.horizon)[0], args.passphrase)
     builder = Builder(NETWORK_NAME, KinClient(env).horizon, MIN_FEE, root_account_seed(args.passphrase))
     builder.sequence = builder.get_sequence()
-    kps = await create_accounts(builder, args.accounts, STARTING_BALANCE)
+    kps = await create_accounts(builder, args.horizon, args.accounts, STARTING_BALANCE)
 
     for kp in kps:
         print(kp.secret_seed)

--- a/tests/python/helpers.py
+++ b/tests/python/helpers.py
@@ -1,45 +1,197 @@
 import asyncio
+import logging
+import math
 from hashlib import sha256
+from typing import List
+
+import aiohttp
+
+from kin import Keypair, Environment
+from kin.blockchain.horizon import Horizon
 from kin.blockchain.builder import Builder
-from kin import Keypair
+from kin.config import SDK_USER_AGENT
 from kin_base import Keypair as BaseKeypair
 
-from concurrent.futures import ThreadPoolExecutor
+import kin
+import kin_base
+
+NETWORK_NAME = 'LOCAL'
+MIN_FEE = 100
+MAX_OPS = 100
+TX_SET_SIZE = 500
+
+
+def root_account_seed(passphrase: str) -> str:
+    """Return the root account seed based on the given network passphrase."""
+    network_hash = sha256(passphrase.encode()).digest()
+    return kin_base.Keypair.from_raw_seed(network_hash).seed().decode()
 
 
 def derive_root_account(passphrase):
-    """Return the keypair of the root account, based on the network passphrase"""
+    """Return the keypair of the root account, based on the network passphrase."""
     network_hash = sha256(passphrase.encode()).digest()
     seed = BaseKeypair.from_raw_seed(network_hash).seed().decode()
     return Keypair(seed)
 
 
-async def send_txs(txs):
-    with ThreadPoolExecutor(max_workers=len(txs)) as executor:
-        loop = asyncio.get_running_loop()
-        promises = [loop.run_in_executor(executor, tx.submit) for tx in txs]
+async def create_accounts(env: Environment, channels: List[Builder], root_account: BaseKeypair, starting_balance, horizon_addresses: List[str] = []):
+    """Asynchronously create accounts and return a transaction Builder instance for each account.
 
-        for _ in await asyncio.gather(*promises):
-            return promises
+    Each Builder instance uses a different Horizon endpoint if given a non-empty list.
+    """
+    accounts_to_create_num = len(channels) * MAX_OPS
+    logging.info('creating %d accounts', accounts_to_create_num)
+
+    accounts_to_create = [Keypair() for _ in range(accounts_to_create_num)]
+    xdrs = []
+    for i, channel in enumerate(channels):
+        for kp in accounts_to_create[i*MAX_OPS : i*(MAX_OPS) + MAX_OPS]:
+            # use the root account as the source of the operations
+            #
+            # NOTE channels need a starting balance since they need to pay fees because they are not prioritized
+            channel.append_create_account_op(source=root_account.address(),
+                                             destination=kp.public_address,
+                                             starting_balance=str(starting_balance))
+
+        # sign with channel and root account
+        channel.sign(secret=channel.keypair.seed().decode())
+        if root_account.seed().decode() != channel.keypair.seed().decode():
+            channel.sign(secret=root_account.seed().decode())
+        xdrs.append(channel.gen_xdr())
+
+        channel.next()
+
+    horizon_uri = channels[0].horizon.horizon_uri
+    await send_txs(horizon_uri, xdrs, expected_statuses=[200])
+
+    # fetch sequence numbers asynchronously for all created accounts
+    sequences = await get_sequences(horizon_uri, [a.public_address for a in accounts_to_create])
+
+    # create tx builders with up-to-date sequence number
+    builders = []
+    horizons = ([Horizon(horizon_uri=addr, user_agent=SDK_USER_AGENT) for addr in horizon_addresses]
+                if horizon_addresses
+                else [horizon_uri])
+    for i, kp in enumerate(accounts_to_create):
+        # deterministically pick horizon endpoint from all available endpoint
+        # according to keypair index in account list
+        horizon = horizons[i % len(horizons)]
+        builder = Builder(env.name, horizon, MIN_FEE, kp.secret_seed)
+        builder.sequence = sequences[i]
+        builders.append(builder)
+
+    for b in builders:
+        logging.debug('created builder %s', b.address)
+
+    return builders
+
+
+def init_tx_builders(env, kps, sequences):
+    """Initialize transaction builders for each given seed."""
+    builders = []
+    for i, kp in enumerate(kps):
+        client = kin.KinClient(env)
+        builder = Builder(env.name, client.horizon, MIN_FEE, kp.secret_seed)
+        builder.sequence = sequences[i]
+        builders.append(builder)
+    return builders
+
+
+async def get(session: aiohttp.ClientSession, url, expected_status=200):
+    """Send an HTTP GET request and return response JSON data.
+
+    Fail if response isn't expected status code or format other than JSON.
+    """
+    async with session.get(url) as res:
+        res_data = await res.json()
+
+        if res.status != expected_status:
+            logging.error('Error in HTTP GET request to %s: %s', url, res_data)
+            raise RuntimeError('Error in HTTP GET request to {}'.format(url))
+
+    return res_data
+
+
+async def post(session: aiohttp.ClientSession, url, req_data, expected_statuses):
+    """Send an HTTP POST request with given data and return response JSON data.
+
+    Fail if response isn't expected status code or format other than JSON.
+
+    NOTE expected status is either OK 200 or Server Timeout 504 if the transaction
+    wasn't added to the next three ledgers.
+    """
+    async with session.post(url, data=req_data) as res:
+        res_data = await res.json()
+
+        if res.status not in expected_statuses:
+            logging.error('Error in HTTP POST request to %s with data %s: %s', url, req_data, res_data)
+            raise RuntimeError('Error in HTTP POST request to {}'.format(url))
+
+    return res_data
+
+
+class LoggingClientSession(aiohttp.ClientSession):
+    """aiohttp client session that logs requests."""
+
+    async def _request(self, method, url, **kwargs):
+        logging.debug('Starting request <%s %r>', method, url)
+        return await super()._request(method, url, **kwargs)
+
+
+async def send_txs(endpoint, xdrs, expected_statuses=[200, 504]):
+    """Send multiple async transaction XDRs to given endpoint."""
+    logging.info('sending %d transactions', len(xdrs))
+
+    async with LoggingClientSession(connector=aiohttp.TCPConnector(limit=5000)) as session:
+        url = '{}/transactions'.format(endpoint)
+        results = await asyncio.gather(*[post(session, url, {'tx': xdr.decode()}, expected_statuses) for xdr in xdrs])
+
+    logging.info('%d transactions sent', len(xdrs))
+    return results
+
+
+async def get_sequences(endpoint, addresses):
+    """Get sequence for multiple accounts."""
+    logging.info('getting sequence for %d accounts', len(addresses))
+
+    async with LoggingClientSession() as session:
+        url = '{}/accounts'.format(endpoint)
+        results = await asyncio.gather(*[get(session, '{}/{}'.format(url, address)) for address in addresses])
+
+    logging.info('finished getting sequence for %d accounts', len(addresses))
+
+    sequences = [int(r['sequence']) for r in results]
+    return sequences
 
 
 def get_latest_ledger(client):
     params = {'order': 'desc', 'limit': 1}
     return client.horizon.ledgers(params=params)['_embedded']['records'][0]
 
-def create_whitelisted_account(client, wlSecret, account):
-    builder = Builder('LOCAL', client.horizon, fee=client.get_minimum_fee(), secret=wlSecret)
-    builder.get_sequence()
-    builder.append_manage_data_op(account.public_address, account._hint)
-    builder.sign()
-    builder.submit()
+
+def add_prioritizers(builder: Builder, kps: List[Keypair]):
+    """Add given addresses to whitelist account, making them transaction prioritizers."""
+    logging.info('adding %d prioritizers', len(kps))
+
+    for batch_index in range(max(1, math.ceil(len(kps)/MAX_OPS))):
+        start = batch_index*MAX_OPS
+        end = min((batch_index+1)*MAX_OPS,
+                  len(kps))
+
+        for i, kp in enumerate(kps[start:end], start=1):
+            logging.debug('adding manage data op #%d', i)
+            builder.append_manage_data_op(kp.public_address, kp._hint)
+
+        builder.sign()
+
+        logging.debug('submitting transaction with %d manage data ops', end-start)
+        builder.submit()
+        logging.debug('done')
+
+        builder.clear()
+
+    logging.info('%d prioritizers added', len(kps))
 
 
-def remove_whitelisted_account(client, wlSecret, account):
-    builder = Builder('LOCAL', client.horizon, fee=client.get_minimum_fee(), secret=wlSecret)
-    builder.get_sequence()
-    builder.append_manage_data_op(account.public_address, ''.encode())
-    builder.sign()
-    builder.submit()
-
-
+# TODO
+# def remove_whitelisters(builder: Builder, kps: List[kin_base.Keypair]): pass

--- a/tests/python/helpers.py
+++ b/tests/python/helpers.py
@@ -61,7 +61,7 @@ async def generate_keypairs(n) -> List[Keypair]:
     return kps
 
 
-async def create_accounts(source: Builder, accounts_num, starting_balance):
+async def create_accounts(source: Builder, horizon_endpoints, accounts_num, starting_balance):
     """Asynchronously create accounts and return a Keypair instance for each created account."""
     logging.info('creating %d accounts', accounts_num)
 
@@ -89,7 +89,8 @@ async def create_accounts(source: Builder, accounts_num, starting_balance):
 
         # clean source builder for next transaction
         source.next()
-    await send_txs_multiple_endpoints([source.horizon.horizon_uri], xdrs, expected_statuses=[200])
+
+    await send_txs_multiple_endpoints(horizon_endpoints, xdrs, expected_statuses=[200])
 
     logging.info('created %d accounts', accounts_num)
     return kps

--- a/tests/python/helpers.py
+++ b/tests/python/helpers.py
@@ -37,7 +37,11 @@ def derive_root_account(passphrase):
 async def create_accounts(env: Environment, channels: List[Builder], root_account: BaseKeypair, starting_balance, horizon_addresses: List[str] = []):
     """Asynchronously create accounts and return a transaction Builder instance for each account.
 
-    Each Builder instance uses a different Horizon endpoint if given a non-empty list.
+    The amount of accounts to create is determined by how many channels are given
+    and the maximum operatinos allowed in transaction e.g. 10 channels with 100 max ops
+    would cause 10*100=1000 accounts to be created.
+
+    In addition, each Builder instance uses a different Horizon endpoint if given a non-empty list.
     """
     accounts_to_create_num = len(channels) * MAX_OPS
     logging.info('creating %d accounts', accounts_to_create_num)

--- a/tests/python/network_spammer.py
+++ b/tests/python/network_spammer.py
@@ -1,0 +1,236 @@
+"""Send prioritized and unprioritized transactions and verify prioritized transactions get priority when added to ledgers."""
+import argparse
+import asyncio
+import csv
+import logging
+import math
+import queue
+import time
+from datetime import datetime
+from typing import List
+
+from kin import KinClient, Environment as KinEnvironment, Keypair
+from kin.blockchain.builder import Builder
+
+from helpers import (MIN_FEE, TX_SET_SIZE, NETWORK_NAME,
+                     root_account_seed, create_accounts, add_prioritizers,
+                     send_txs, get_sequences)
+
+
+AVG_BLOCK_TIME = 5  # seconds
+STARTING_BALANCE = 1e5  # for paying unprioritzied tx fees and channels creating spam accounts
+
+# we create enough accounts to submit txs in parallel for this amount of ledgers
+# e.g. if we want 700 tx/ledger, than we will createa 700 * 10 accounts.
+LEDGER_BUFFER = 20
+
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s')
+
+
+def parse_args():
+    """Generate and parse CLI arguments."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--length', required=True, type=int, help='Test length in seconds')
+    parser.add_argument('--txs-per-ledger', required=True, type=int, help='Transaction rate to submit (spam) in parallel for every ledger round')
+    parser.add_argument('--whitelist-seed', required=True, type=str, help='Whitelist account seed')
+    parser.add_argument('--csv', default='spam-results-{}.csv'.format(str(int(time.time()))), type=str, help='Spam results CSV output')
+
+    parser.add_argument('--passphrase', type=str, help='Network passphrase')
+    parser.add_argument('--horizon', action='append',
+                        help='Horizon endpoint URL (use multiple --horizon flags for multiple addresses)')
+
+    return parser.parse_args()
+
+
+def spam(env, prioritizers, builders, length, tx_per_ledger):
+    """Have each account submit transactions every 5s (avg block time) for given length in seconds."""
+    coroutines = []
+
+    # create a queue of builders.
+    # we will fetch a batch of builders for each spam round
+    builders_queue = queue.Queue()
+    for b in builders:
+        builders_queue.put(b)
+
+    rounds = math.ceil(length // AVG_BLOCK_TIME)
+    for rnd in range(rounds):
+        round_builders = [builders_queue.get() for _ in range(tx_per_ledger)]
+
+        coroutines.append(spam_round(env, prioritizers,
+                                     round_builders[:TX_SET_SIZE - 1],
+                                     round_builders[TX_SET_SIZE - 1:tx_per_ledger],
+                                     rnd))
+
+        # push this round's builders to the back of the queue.
+        # they will be reused in the next LEDGER_BUFFER ledger
+        for b in round_builders:
+            builders_queue.put(b)
+
+    return asyncio.gather(*coroutines)
+
+
+# all transactions are payments to the same address
+#
+# TODO can this potentially create deadlocks when applying them?
+async def spam_round(env, prioritizers: List[Keypair], prioritized_builders, unprioritized_builders, rnd):
+    """Send prioritized and unprioritzied transactions for a single ledger.
+
+    All prioritized transactions are expected to be included in the next ledger.
+    Only one out of all unprioritized transactions is expected to be included in the next ledger.
+
+    Return a result list and hash of all submitted transactions.
+    """
+    payment_amount = 1
+    payment_dest = prioritizers[0]  # all transactions are payments to the same address
+
+    # this round should be started only after all previous ledgers have been
+    # added, so we sleep until then
+    await asyncio.sleep(rnd * AVG_BLOCK_TIME)
+
+    # generate unprioritized payment transactions
+    # we submit them first because we want to test if prioritized transactions
+    # actually get priority over them
+    tx_metadata = {}
+    xdrs = []
+    for i, _ in enumerate(unprioritized_builders):
+        builder = unprioritized_builders[i]
+        builder.append_payment_op(payment_dest.public_address, str(payment_amount))
+        builder.sign(builder.keypair.seed().decode())
+
+        xdrs.append(builder.gen_xdr())
+
+        # cache tx hash for later review
+        tx_metadata[builder.hash_hex()] = {'round': rnd,
+                                           'prioritized': False}
+
+    # generate prioritized transactions
+    for i, _ in enumerate(prioritized_builders):
+        builder = prioritized_builders[i]
+        builder.append_payment_op(payment_dest.public_address, str(payment_amount))
+        builder.sign(builder.keypair.seed().decode())
+
+        # prioritize transaction by adding a prioritizer signature
+        builder.sign(prioritizers[i].secret_seed)
+
+        xdrs.append(builder.gen_xdr())
+
+        tx_metadata[builder.hash_hex()] = {'round': rnd,
+                                           'prioritized': True}
+
+    # remember submission time and send txs
+    submission_time = time.time()
+
+    # some transactions can fail with HTTP 500 Server Error or HTTP 504 Server
+    # Timeout, so don't raise an exception if this happens
+    tx_results = await send_txs(env.horizon_uri, xdrs, expected_statuses=[200, 500, 504])
+
+    # fetch builder sequence number.
+    #
+    # NOTE this is necessary because not all transactions have been processed
+    # when we reach this stage,specifically unprioritized ones.
+    # thus, it is unknown if the sequence has increased or not
+    all_builders = prioritized_builders + unprioritized_builders
+    sequences = await get_sequences(prioritized_builders[0].horizon.horizon_uri,
+                                    [b.address for b in all_builders])
+
+    # update builder sequence number
+    for i, _ in enumerate(all_builders):
+        b = all_builders[i]
+        b.clear()
+        b.sequence = str(sequences[i])
+
+    # create tx result object for each tx for reviewing later on
+    results = []
+    for (hsh, metadata), result in zip(tx_metadata.items(), tx_results):
+        try:
+            ledger = result['ledger']
+        except KeyError:  # probably 504
+            ledger = None
+        results.append({'hash': hsh,
+                        'round': metadata['round'],
+                        'prioritized': metadata['prioritized'],
+                        'ledger': ledger,
+                        'submission_time': submission_time})
+
+    return results
+
+
+LEDGERS = {}
+
+
+def ledger_time(ledger, horizon):
+    """Return ledger close time."""
+    # failed txs have ledger = None
+    # so we return an empty timestamp instead
+    if not ledger:
+        return ''
+
+    global LEDGERS
+    if ledger not in LEDGERS:
+        logging.debug('fetching ledger %d', ledger)
+        date_str = horizon.ledger(ledger)['closed_at']
+        LEDGERS[ledger] = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ').timestamp()
+    return LEDGERS[ledger]
+
+
+async def main():
+    args = parse_args()
+
+    # init root account (funder) tx builder
+    env = KinEnvironment(NETWORK_NAME, args.horizon[0], args.passphrase)
+    root_builder = Builder(env.name, KinClient(env).horizon, MIN_FEE, root_account_seed(args.passphrase))
+    root_builder.sequence = root_builder.get_sequence()
+
+    # create channel accounts for mass creating accounts later on
+    # these accounts will consume the sequence number for the root builder
+    # so we can parallelize mass account creation
+    account_creator_channels = await create_accounts(env, [root_builder], root_builder.keypair, STARTING_BALANCE, args.horizon)
+
+    # create prioritizer accounts
+    #
+    # NOTE we create as many prioritizers as there are prioritized txs per
+    # ledger. each prioritizer will prioritzie a single tx
+    #
+    # NOTE we create TX_SET_SIZE - 1 prioritizers because there is at always
+    # one reserved tx for unprioritized
+    #
+    # TODO is this even necessary? can't we just add addresses which belong to
+    # uncreated accounts and be done with it?
+    prioritizer_accounts_num = TX_SET_SIZE - 1
+    logging.info('creating %d prioritizer accounts', prioritizer_accounts_num)
+    prioritizer_builders = await create_accounts(env, account_creator_channels, root_builder.keypair, 0, args.horizon)
+
+    # add prioritizer accounts to the whitelist
+    #
+    # NOTE prioritized accounts have a starting balance of 0 since they wont be
+    # submitting anything
+    prioritizer_kps = [Keypair(b.keypair.seed().decode()) for b in prioritizer_builders[:TX_SET_SIZE - 1]]
+    whitelist_builder = Builder(env.name, KinClient(env).horizon, MIN_FEE, args.whitelist_seed)
+    add_prioritizers(whitelist_builder, prioritizer_kps)
+
+    # create enough spam accounts to maintain stable transaction rate in each ledger.
+    # we assume each account will be able to submit a transaction every LEDGER_BUFFER ledgers.
+    # this is enough time for it to finish its previous tx submission and
+    # update its account sequence.
+    spam_accounts_num = args.txs_per_ledger * LEDGER_BUFFER
+    spam_builders = []
+    for _ in range(math.ceil((spam_accounts_num / 10_000))):
+        spam_builders.extend(await create_accounts(env, account_creator_channels, root_builder.keypair, STARTING_BALANCE, args.horizon))
+
+    # start the spamming test
+    results = await spam(env, prioritizer_kps, spam_builders, args.length, args.txs_per_ledger)
+
+    # save results into csv file
+    horizon = KinClient(env).horizon
+    with open(args.csv, 'w') as csvfile:
+        w = csv.DictWriter(csvfile, fieldnames=list(results[0][0].keys()) + ['ledger_time'])
+        w.writeheader()
+        for spam_round in results:
+            for tx in spam_round:
+                w.writerow({**tx, **{'ledger_time': ledger_time(tx['ledger'], horizon)}})
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/python/prioritize.py
+++ b/tests/python/prioritize.py
@@ -1,0 +1,49 @@
+"""Receive seeds and add them as prioritizers to whitelist account."""
+import argparse
+import logging
+from typing import List
+
+from kin import KinClient, Environment as KinEnvironment, Keypair
+from kin.blockchain.builder import Builder
+
+from helpers import NETWORK_NAME, MIN_FEE, add_prioritizers
+
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+
+
+def parse_args():
+    """Generate and parse CLI arguments."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--whitelist-seed', required=True, type=str, help='Whitelist account seed')
+    parser.add_argument('--prioritizer-seeds-file', required=True, type=str, help='File path to prioritizer seeds file')
+    parser.add_argument('--passphrase', required=True, type=str, help='Network passphrase')
+    parser.add_argument('--horizon', required=True, type=str, help='Horizon endpoint URL')
+
+    return parser.parse_args()
+
+
+def load_accounts(path) -> List[Keypair]:
+    """Load seeds from file path and return Keypair list.
+
+    Expected file format is a newline-delimited seed list.
+    """
+    kps = []
+    with open(path) as f:
+        for seed in f:
+            kps.append(Keypair(seed.strip()))
+    return kps
+
+
+def main():
+    """Receive seeds and add them as prioritizers to whitelist account."""
+    args = parse_args()
+    env = KinEnvironment(NETWORK_NAME, args.horizon, args.passphrase)
+    prioritizer_kps = load_accounts(args.prioritizer_seeds_file)
+    whitelist_builder = Builder(env.name, KinClient(env).horizon, MIN_FEE, args.whitelist_seed)
+    add_prioritizers(whitelist_builder, prioritizer_kps)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python/report.py
+++ b/tests/python/report.py
@@ -1,0 +1,65 @@
+import argparse
+import csv
+import json
+import logging
+import time
+from datetime import datetime
+
+from kin.blockchain.horizon import Horizon
+from kin.config import SDK_USER_AGENT
+
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s')
+
+
+def parse_args():
+    """Generate and parse CLI arguments."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--input', type=str, help='Spam results JSON output')
+    parser.add_argument('--output', default='spam-results-{}.csv'.format(str(int(time.time()))), type=str, help='Spam results CSV output')
+    parser.add_argument('--horizon', type=str, help='Horizon endpoint URL')
+
+    return parser.parse_args()
+
+
+LEDGERS = {}
+
+
+def ledger_time(ledger, horizon):
+    """Return ledger close time."""
+    # failed txs have ledger = None
+    # so we return an empty timestamp instead
+    if not ledger:
+        return ''
+
+    global LEDGERS
+    if ledger not in LEDGERS:
+        logging.debug('fetching ledger %d', ledger)
+        date_str = horizon.ledger(ledger)['closed_at']
+        LEDGERS[ledger] = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ').timestamp()
+    return LEDGERS[ledger]
+
+
+def main():
+    args = parse_args()
+
+    logging.info('reading spam results')
+    results = []
+    with open(args.input) as f:
+        for l in f:
+            results.append(json.loads(l))
+
+    logging.info('generating report csv')
+    horizon = Horizon(horizon_uri=args.horizon, user_agent=SDK_USER_AGENT)
+    with open(args.output, 'w') as csvfile:
+        w = csv.DictWriter(csvfile, fieldnames=list(results[0].keys()) + ['ledger_time'])
+        w.writeheader()
+        for tx in results:
+            w.writerow({**tx, **{'ledger_time': ledger_time(tx['ledger'], horizon)}})
+
+    logging.info('done')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python/stress.py
+++ b/tests/python/stress.py
@@ -209,7 +209,7 @@ async def main():
     stub_horizon = args.horizon[0]
     for kp, seq in zip(spam_kps, spam_sequences):
         b = Builder(NETWORK_NAME, stub_horizon, MIN_FEE, kp.secret_seed)
-        b.sequence = str(seq + 1)
+        b.sequence = str(seq)
         spam_builders.append(b)
 
     logging.info('sleeping for %ds to let horizon cool down after get sequence request surge', COOL_DOWN_AFTER_GET_SEQ)

--- a/tests/python/stress.py
+++ b/tests/python/stress.py
@@ -9,7 +9,7 @@ import time
 from datetime import datetime
 from typing import List
 
-from kin import Keypair
+from kin import Keypair, Environment
 from kin.blockchain.builder import Builder
 from kin.blockchain.horizon import Horizon
 from kin.config import SDK_USER_AGENT
@@ -189,6 +189,9 @@ def ledger_time(ledger, horizon):
 
 async def main():
     args = parse_args()
+
+    # setup network
+    Environment(NETWORK_NAME, args.horizon[0], args.passphrase)
 
     logging.info('loading prioritizer accounts')
     prioritizer_kps = [kp for kp in load_accounts(args.prioritizer_seeds_file)]

--- a/tests/python/stress.py
+++ b/tests/python/stress.py
@@ -22,7 +22,7 @@ AVG_BLOCK_TIME = 5  # seconds
 COOL_DOWN_AFTER_GET_SEQ = 10  # seconds
 
 
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
 
 def parse_args():

--- a/tests/python/test_multiple_cores.py
+++ b/tests/python/test_multiple_cores.py
@@ -57,7 +57,7 @@ async def main():
         accounts[0].public_address)
     print('2 Test accounts created - Passed')
 
-    for i in tx_count:
+    for i in range(tx_count):
         # generating transactions using multiple kin-cores
         builder = Builder('LOCAL', clients[i % len(clients)].horizon, fee=minimum_fee,
                           secret=accounts[i % len(accounts)].secret_seed)


### PR DESCRIPTION
the test jumps through a lot of loops in order to make the kin python sdk use
async, since it's necessary to implement stress tests, which is what this is
test is all about.

the code is not the easiest to read as it could be, but this will be
remedied once the kin python sdk will be updated to natively support
asyncio and aiohttp python packages.

in addition, this pr add plenty of helper functions to help with common
tasks e.g. creating accounts, submitting txs, get sequences, all in an
async manner