### PR TITLE
configure core parameters like max-tx-size after core is launched

### DIFF
--- a/deploy/ansible/playbooks/roles/stellar-core/tasks/main.yml
+++ b/deploy/ansible/playbooks/roles/stellar-core/tasks/main.yml
@@ -48,3 +48,8 @@
 - name: start stellar-core
   docker_service:
     project_src: /opt/stellar-core
+
+- name: configure core parameters
+  uri:
+    url: http://localhost:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&basereserve=0&maxtxsize=500&protocolversion=9'
+    method: GET


### PR DESCRIPTION
after the core starts, send a configuration command to set protocol version, max-tx-size and basereserve