### PR TITLE
expose horizon healthcheck endpoint

### DIFF
--- a/images/dockerfiles/horizon-nginx-proxy/nginx.conf.tmpl
+++ b/images/dockerfiles/horizon-nginx-proxy/nginx.conf.tmpl
@@ -48,6 +48,10 @@ http {
       return 200;
     }
 
+    location /status {
+      proxy_pass http://localhost:8001/status;
+    }
+
     # metrics
     location /nginx_status {
       allow 127.0.0.1;


### PR DESCRIPTION
this will allow health-checks from the outside world (and not just from amazon's lb/route53)
