### PR TITLE
update quickstart image core version

### DIFF
--- a/apps/docker-quickstart/Makefile
+++ b/apps/docker-quickstart/Makefile
@@ -1,13 +1,16 @@
 __PHONY__: build build-testing
 
+CORE_VERSION := kinecosystem-v2.1.0-stellar-v9.2.0
+HORIZON_VERSION := kinecosystem-v2.0.0-stellar-v0.16.1
+
 core-binary:
-	docker pull kinecosystem/stellar-core:latest
-	docker run -d --name stellar-core-binary --rm --entrypoint sleep kinecosystem/stellar-core:latest 5
+	docker pull kinecosystem/stellar-core:${CORE_VERSION}
+	docker run -d --name stellar-core-binary --rm --entrypoint sleep kinecosystem/stellar-core:${CORE_VERSION} 5
 	docker cp $$(docker inspect --format="{{.Id}}" stellar-core-binary):/usr/local/bin/stellar-core ./
 
 horizon-binary:
-	docker pull kinecosystem/horizon:latest
-	docker run -d --name horizon-binary --rm --entrypoint sleep kinecosystem/horizon:latest 5
+	docker pull kinecosystem/horizon:${HORIZON_VERSION}
+	docker run -d --name horizon-binary --rm --entrypoint sleep kinecosystem/horizon:${HORIZON_VERSION} 5
 	docker cp $$(docker inspect --format="{{.Id}}" horizon-binary):/usr/local/bin/horizon ./
 
 build: core-binary horizon-binary


### PR DESCRIPTION
also use variables to avoid redundancy in makefile