### PR TITLE
add a docker image for gathering blockchain healthchecks

### DIFF
--- a/images/dockerfiles/blockchain-healthcheck-telegraf/Dockerfile
+++ b/images/dockerfiles/blockchain-healthcheck-telegraf/Dockerfile
@@ -1,0 +1,17 @@
+FROM telegraf:1.9.5-alpine
+
+EXPOSE 8086
+
+# input exec plugin dependencies
+RUN apk add -qU --no-cache curl gettext
+
+COPY ./entrypoint.sh /
+
+# custom telegraf input.exec plugins
+RUN mkdir -p /opt/telegraf
+
+# telegraf configuration template
+COPY ./telegraf.conf.tmpl /etc/telegraf/telegraf.conf.tmpl
+
+ENTRYPOINT []
+CMD /entrypoint.sh

--- a/images/dockerfiles/blockchain-healthcheck-telegraf/build-and-push.sh
+++ b/images/dockerfiles/blockchain-healthcheck-telegraf/build-and-push.sh
@@ -1,0 +1,3 @@
+docker build . -t kinecosystem/blockchain-healthcheck-telegraf:v1.0.0
+docker push kinecosystem/blockchain-healthcheck-telegraf:v1.0.0
+

--- a/images/dockerfiles/blockchain-healthcheck-telegraf/entrypoint.sh
+++ b/images/dockerfiles/blockchain-healthcheck-telegraf/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# process telegraf configuration template and start telegraf
+envsubst '$NODE_NAME $NETWORK_NAME' < /etc/telegraf/telegraf.conf.tmpl > /etc/telegraf/telegraf.conf
+exec telegraf

--- a/images/dockerfiles/blockchain-healthcheck-telegraf/telegraf.conf.tmpl
+++ b/images/dockerfiles/blockchain-healthcheck-telegraf/telegraf.conf.tmpl
@@ -1,0 +1,123 @@
+# Telegraf configuration for stellar core
+
+# Global tags can be specified here in key="value" format.
+[tags]
+  app = "healthcheck"
+  node_name = "$NODE_NAME" # take from env
+  stellar_network = "$NETWORK_NAME" # take from env
+
+# Configuration for telegraf agent
+[agent]
+  # Default data collection interval for all inputs
+  interval = "10s"
+  # Rounds collection interval to 'interval'
+  # ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  # Telegraf will cache metric_buffer_limit metrics for each output, and will
+  # flush this buffer on a successful write.
+  metric_buffer_limit = 10000
+
+  # Collection jitter is used to jitter the collection by a random amount.
+  # Each plugin will sleep for a random time within jitter before collecting.
+  # This can be used to avoid many plugins querying things like sysfs at the
+  # same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  # Default data flushing interval for all outputs. You should not set this below
+  # interval. Maximum flush_interval will be flush_interval + flush_jitter
+  flush_interval = "10s"
+  # Jitter the flush interval by a random amount. This is primarily to avoid
+  # large write spikes for users running a large number of telegraf instances.
+  # ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  # Run telegraf in debug mode
+  debug = false
+  # Run telegraf in quiet mode
+  quiet = false
+  # Override default hostname, if empty use os.Hostname()
+  hostname = ""
+
+###############################################################################
+#        OUTPUTS: Expose Prometheus endpoint                                  #
+###############################################################################
+# Publish all metrics to /metrics for Prometheus to scrape
+[[outputs.prometheus_client]]
+  ## Address to listen on.
+  listen = ":9273"
+
+  ## Path to publish the metrics on.
+  path = "/metrics"
+
+  ## Expiration interval for each metric. 0 == no expiration
+  expiration_interval = "60s"
+
+  ## Send string metrics as Prometheus labels.
+  ## Unless set to false all string metrics will be sent as labels.
+  # string_as_label = true
+
+  ## Export metric collection time.
+  #export_timestamp = false
+
+
+###############################################################################
+#                                  INPUTS                                     #
+###############################################################################
+# HTTP/HTTPS request given an address a method and a timeout
+[[inputs.http_response]]
+
+  ## List of urls to query.
+  address = "http://horizon-block-explorer.kininfrastructure.com/status"
+
+  ## Set response_timeout (default 5 seconds)
+  response_timeout = "2s"
+
+  ## HTTP Request Method
+  method = "GET"
+
+[[inputs.http_response]]
+
+  ## List of urls to query.
+  address = "http://horizon.kinfederation.com/status"
+
+  ## Set response_timeout (default 5 seconds)
+  response_timeout = "2s"
+
+  ## HTTP Request Method
+  method = "GET"
+
+[[inputs.http_response]]
+
+  ## List of urls to query.
+  address = "https://www.mykinwallet.org"
+
+  ## Set response_timeout (default 5 seconds)
+  response_timeout = "2s"
+
+  ## HTTP Request Method
+  method = "GET"
+
+[[inputs.http_response]]
+
+  ## List of urls to query.
+  address = "https://laboratory.kin.org/"
+
+  ## Set response_timeout (default 5 seconds)
+  response_timeout = "2s"
+
+  ## HTTP Request Method
+  method = "GET"
+
+[[inputs.http_response]]
+
+  ## List of urls to query.
+  address = "https://horizon-testnet.kininfrastructure.com/status"
+
+  ## Set response_timeout (default 5 seconds)
+  response_timeout = "2s"
+
+  ## HTTP Request Method
+  method = "GET"
+
+# vim: ft=toml


### PR DESCRIPTION
adds a telegraf image to periodically sample some of our production sites. this data is then gathered by prometheus and presented on a dashboard.