### PR TITLE
Fix typos

### DIFF
--- a/apps/docker-quickstart/README.md
+++ b/apps/docker-quickstart/README.md
@@ -200,7 +200,7 @@ $ docker run --rm -it \
 $ docker run -it --rm \
     -v "/str:/opt/stellar" \
     --name stellar \
-    kineosystem/blockchain-quickstart --mainnet
+    kinecosystem/blockchain-quickstart --mainnet
 ```
 
 *Start a background persistent container for an already initialized host directory:*
@@ -209,5 +209,5 @@ $ docker run -d \
     -v "/str:/opt/stellar" \
     -p "8000:8000" \
     --name stellar \
-    kineosystem/blockchain-quickstart --mainnet
+    kinecosystem/blockchain-quickstart --mainnet
 ```


### PR DESCRIPTION
Copy-pasting these commands give the following error:

```
docker: Error response from daemon: pull access denied for kineosystem/blockchain-quickstart, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```

Luckily it turned out to be a typo, fixed by this patch!